### PR TITLE
fix extact task id

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -63,5 +63,5 @@ func ExtractTaskId(taskArn string) string {
 		log.Fatal("seems passed parameter is not task ARN")
 	}
 
-	return strings.Split(taskArn, "/")[1]
+	return strings.Split(taskArn, "/")[2]
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -10,11 +10,11 @@ func TestExtractTaskId(t *testing.T) {
 		expect string
 	}{
 		{
-			param:  "foo/bar",
+			param:  "foo/test/bar",
 			expect: "bar",
 		},
 		{
-			param:  "aws:arn:~~/dea2ccc0-da13-462d-88ce-f65aa7764d98",
+			param:  "aws:arn:~~/ecs-name-cluster/dea2ccc0-da13-462d-88ce-f65aa7764d98",
 			expect: "dea2ccc0-da13-462d-88ce-f65aa7764d98",
 		},
 	}


### PR DESCRIPTION
keys -v didn't return taskid
It returned the name ECS cluster